### PR TITLE
python3 shebang fix

### DIFF
--- a/auto-smart-commit.py
+++ b/auto-smart-commit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import sys


### PR DESCRIPTION
The styling of python3 metadata doc strings, means that auto-smart-commit.py is not compilable against python3.
This breaks systems that have python2 installed and python3, as alot of OS have python2 as based Python, and she shebang ignores aliasing, thus to make this work on systems such as macbooks have to do changes which can damage your OS.
It seems reasonable to expect python3 shebang if not backwards compatible.